### PR TITLE
Remove old svnbridge files

### DIFF
--- a/DependencyAnalyzer2005/..svnbridge/.svnbridge
+++ b/DependencyAnalyzer2005/..svnbridge/.svnbridge
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>bin
-obj
-</Value></Property><Property><Name>svn:ignore</Name><Value>Archive
-bin
-obj
-</Value></Property></Properties></ItemProperties>

--- a/DependencyAnalyzer2008/..svnbridge/.svnbridge
+++ b/DependencyAnalyzer2008/..svnbridge/.svnbridge
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>bin
-obj
-</Value></Property><Property><Name>svn:ignore</Name><Value>bin
-obj
-*.bak
-</Value></Property></Properties></ItemProperties>

--- a/DependencyExecutor/..svnbridge/.svnbridge
+++ b/DependencyExecutor/..svnbridge/.svnbridge
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>bin
-obj
-</Value></Property></Properties></ItemProperties>

--- a/DependencyViewer/..svnbridge/.svnbridge
+++ b/DependencyViewer/..svnbridge/.svnbridge
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>bin
-obj
-</Value></Property><Property><Name>svn:ignore</Name><Value>bin
-obj
-*.user
-</Value></Property></Properties></ItemProperties>

--- a/DependencyViewer/..svnbridge/Web.ico
+++ b/DependencyViewer/..svnbridge/Web.ico
@@ -1,1 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:mime-type</Name><Value>application/octet-stream</Value></Property></Properties></ItemProperties>

--- a/Reports/..svnbridge/.svnbridge
+++ b/Reports/..svnbridge/.svnbridge
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>*.data
-bin
-</Value></Property></Properties></ItemProperties>

--- a/Reports/..svnbridge/Reports.rptproj.user
+++ b/Reports/..svnbridge/Reports.rptproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>*.suo
-UpgradeLog.XML
-_UpgradeReport_Files
-</Value></Property><Property><Name>svn:mime-type</Name><Value>application/octet-stream</Value></Property></Properties></ItemProperties>

--- a/SQL/..svnbridge/SSIS_Meta_creation.sql
+++ b/SQL/..svnbridge/SSIS_Meta_creation.sql
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>*.suo
-UpgradeLog.XML
-_UpgradeReport_Files
-</Value></Property><Property><Name>svn:mime-type</Name><Value>application/octet-stream</Value></Property></Properties></ItemProperties>

--- a/SQLServerMetadataToolkit/..svnbridge/.svnbridge
+++ b/SQLServerMetadataToolkit/..svnbridge/.svnbridge
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>Debug
-Release
-</Value></Property></Properties></ItemProperties>

--- a/TSQLParser/..svnbridge/.svnbridge
+++ b/TSQLParser/..svnbridge/.svnbridge
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?><ItemProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Properties><Property><Name>svn:ignore</Name><Value>bin
-obj
-</Value></Property></Properties></ItemProperties>


### PR DESCRIPTION
Hi,

I will not be able to get the project connection managers working, but can do some cleanup ;).

When this project was on CodePlex the svnbridge was used. See  https://archive.codeplex.com/?p=svnbridge . This is not useful for github anymore.

regards