### PR TITLE
Fix keif888/SQLServerMetadata#3 Use table logic for DSV Views without…

### DIFF
--- a/DependencyAnalyzer2008/SSASEnumerator.cs
+++ b/DependencyAnalyzer2008/SSASEnumerator.cs
@@ -234,6 +234,23 @@ namespace Microsoft.Samples.DependencyAnalyzer
                             {
                                 repository.AddAttribute(dsvTableID, Repository.Attributes.QueryDefinition, queryDefinition.ToString());
                             }
+                            else
+                            {
+                                // if query definition is missing it's not a Named Query in DSV. Handle it like a normal table, copied code from table logic abvove
+                                // now add the table
+                                string tableName = GetFullyQualifiedTableName(table);
+
+                                if (threePartNames)
+                                    tableName = String.Format("[{0}].{1}", repository.RetrieveDatabaseNameFromConnectionID(connectionID), tableName);
+                                int tableID = repository.GetTable(connectionID, tableName);
+                                if (tableID == -1)
+                                {
+                                    tableID = repository.AddObject(tableName, string.Empty, RelationalEnumerator.ObjectTypes.Table, connectionID);
+                                }
+
+                                // add the lineage
+                                repository.AddMapping(tableID, dsvTableID);
+                            }
                         }
                     }
                 }

--- a/DependencyAnalyzer2008/SsisEnumerator.cs
+++ b/DependencyAnalyzer2008/SsisEnumerator.cs
@@ -710,7 +710,14 @@ namespace Microsoft.Samples.DependencyAnalyzer
                     // This seems to be needed for SQL 2012, but not later versions.
                     foreach (ConnectionManagerItem cmi in ssisProject.ConnectionManagerItems)
                     {
-                        log.InfoFormat("Discovered connection manager {0}", cmi.ConnectionManager.Name);
+                        try
+                        {
+                            log.InfoFormat("Discovered connection manager {0}", cmi.ConnectionManager.Name);
+                        }
+                        catch (Exception ex)
+                        {
+                            log.ErrorFormat("Unabled to create connection manager: {0}\nStack Trace:\n{1}.", ex.Message, ex.StackTrace);
+                        }
                     }
                     // Parse each and every package in the project.
                     foreach (PackageItem pi in ssisProject.PackageItems)


### PR DESCRIPTION
Fix #3 Use table logic for DSV Views without QueryDefinition. DSV Views without QueryDefinition are handeld as SQL Server Database Views